### PR TITLE
Add PostgreSQL and Kafka+Zookeeper deployers for Docker and Kubernetes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,3 +31,19 @@ includes:
 
 tasks:
   default: task --list-all
+
+  test-docker-kafka:
+    desc: Full integration test for Docker Kafka + Zookeeper
+    cmds:
+      - task: docker-zookeeper:create
+      - task: docker-zookeeper:wait
+      - task: docker-kafka:test
+      - task: docker-zookeeper:remove
+
+  test-kube-kafka:
+    desc: Full integration test for Kube Kafka + Zookeeper
+    cmds:
+      - task: kube-zookeeper:create
+      - task: kube-zookeeper:wait
+      - task: kube-kafka:test
+      - task: kube-zookeeper:remove

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,12 +4,30 @@ includes:
   docker-redis:
     taskfile: ./docker-redis/Taskfile.yml
     dir: ./docker-redis
+  docker-postgres:
+    taskfile: ./docker-postgres/Taskfile.yml
+    dir: ./docker-postgres
+  docker-zookeeper:
+    taskfile: ./docker-zookeeper/Taskfile.yml
+    dir: ./docker-zookeeper
+  docker-kafka:
+    taskfile: ./docker-kafka/Taskfile.yml
+    dir: ./docker-kafka
   kube-kind:
     taskfile: ./kube-kind/Taskfile.yml
     dir: ./kube-kind
   kube-redis:
     taskfile: ./kube-redis/Taskfile.yml
     dir: ./kube-redis
+  kube-postgres:
+    taskfile: ./kube-postgres/Taskfile.yml
+    dir: ./kube-postgres
+  kube-zookeeper:
+    taskfile: ./kube-zookeeper/Taskfile.yml
+    dir: ./kube-zookeeper
+  kube-kafka:
+    taskfile: ./kube-kafka/Taskfile.yml
+    dir: ./kube-kafka
 
 tasks:
   default: task --list-all

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -52,14 +52,14 @@ tasks:
     silent: true
 
   test:
-    desc: Run a test for Kafka (starts Zookeeper, then Kafka)
+    desc: Run a test for Kafka (requires Zookeeper to be running)
+    preconditions:
+      - sh: docker ps --filter "name=zookeeper-server" --filter "status=running" --format '{{`{{.Names}}`}}' | grep -q zookeeper-server
+        msg: "Zookeeper is not running. Start it first with: task docker-zookeeper:create && task docker-zookeeper:wait"
     cmds:
-      - task -d .. docker-zookeeper:create
-      - task -d .. docker-zookeeper:wait
       - task: create
       - task: status
       - task: logs
       - task: remove
-      - task -d .. docker-zookeeper:remove
       - task: status
     silent: false

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -54,12 +54,12 @@ tasks:
   test:
     desc: Run a test for Kafka (starts Zookeeper, then Kafka)
     cmds:
-      - task docker-zookeeper:create
-      - task docker-zookeeper:wait
+      - task -d .. docker-zookeeper:create
+      - task -d .. docker-zookeeper:wait
       - task: create
       - task: status
       - task: logs
       - task: remove
-      - task docker-zookeeper:remove
+      - task -d .. docker-zookeeper:remove
       - task: status
     silent: false

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -15,14 +15,14 @@ tasks:
   create:
     desc: Run the Kafka container
     cmds:
+      - docker network create taskops-net 2>/dev/null || true
       - docker rm -f {{.CONTAINER_NAME}} 2>/dev/null || true
       - >
-        docker run -d --name {{.CONTAINER_NAME}} -p 9092:9092
+        docker run -d --name {{.CONTAINER_NAME}} --network taskops-net -p 9092:9092
         -e KAFKA_ZOOKEEPER_CONNECT=zookeeper-server:2181
         -e KAFKA_LISTENERS=PLAINTEXT://:9092
         -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
         -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT
-        --link zookeeper-server
         {{.IMAGE}}
     silent: true
 
@@ -60,6 +60,7 @@ tasks:
     desc: Run a test for Kafka (starts Zookeeper, then Kafka)
     cmds:
       - task: docker-zookeeper:create
+      - sleep 5
       - task: create
       - task: status
       - task: logs

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -1,0 +1,63 @@
+version: 3
+
+vars:
+  IMAGE: bitnami/kafka:latest
+  CONTAINER_NAME: kafka-server
+
+tasks:
+  default: task --list-all
+
+  create:
+    desc: Run the Kafka container
+    cmds:
+      - >
+        docker run -d --name {{.CONTAINER_NAME}} -p 9092:9092
+        -e KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper-server:2181
+        -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+        -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+        -e ALLOW_PLAINTEXT_LISTENER=yes
+        --link zookeeper-server
+        {{.IMAGE}}
+    silent: true
+
+  stop:
+    desc: Stop the Kafka container
+    cmds:
+      - docker stop {{.CONTAINER_NAME}}
+    silent: true
+
+  remove:
+    desc: Remove the Kafka container
+    cmds:
+      - docker rm -f {{.CONTAINER_NAME}}
+    silent: true
+
+  logs:
+    desc: View the logs of the Kafka container
+    cmds:
+      - docker logs {{.CONTAINER_NAME}}
+    silent: false
+
+  cli:
+    desc: Open a shell in the Kafka container
+    cmds:
+      - docker exec -it {{.CONTAINER_NAME}} bash
+    silent: false
+
+  status:
+    desc: Check the status of the Kafka container
+    cmds:
+      - docker ps -a --filter "name={{.CONTAINER_NAME}}"
+    silent: true
+
+  test:
+    desc: Run a test for Kafka (starts Zookeeper, then Kafka)
+    cmds:
+      - task: docker-zookeeper:create
+      - task: create
+      - task: status
+      - task: logs
+      - task: remove
+      - task: docker-zookeeper:remove
+      - task: status
+    silent: false

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -1,10 +1,5 @@
 version: 3
 
-includes:
-  docker-zookeeper:
-    taskfile: ../docker-zookeeper/Taskfile.yml
-    dir: ../docker-zookeeper
-
 vars:
   IMAGE: apache/kafka:latest
   CONTAINER_NAME: kafka-server
@@ -59,12 +54,12 @@ tasks:
   test:
     desc: Run a test for Kafka (starts Zookeeper, then Kafka)
     cmds:
-      - task: docker-zookeeper:create
-      - sleep 5
+      - task docker-zookeeper:create
+      - task docker-zookeeper:wait
       - task: create
       - task: status
       - task: logs
       - task: remove
-      - task: docker-zookeeper:remove
+      - task docker-zookeeper:remove
       - task: status
     silent: false

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -6,7 +6,7 @@ includes:
     dir: ../docker-zookeeper
 
 vars:
-  IMAGE: bitnami/kafka:latest
+  IMAGE: apache/kafka:latest
   CONTAINER_NAME: kafka-server
 
 tasks:
@@ -17,10 +17,10 @@ tasks:
     cmds:
       - >
         docker run -d --name {{.CONTAINER_NAME}} -p 9092:9092
-        -e KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper-server:2181
-        -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
-        -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
-        -e ALLOW_PLAINTEXT_LISTENER=yes
+        -e KAFKA_ZOOKEEPER_CONNECT=zookeeper-server:2181
+        -e KAFKA_LISTENERS=PLAINTEXT://:9092
+        -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+        -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT
         --link zookeeper-server
         {{.IMAGE}}
     silent: true

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -15,6 +15,7 @@ tasks:
   create:
     desc: Run the Kafka container
     cmds:
+      - docker rm -f {{.CONTAINER_NAME}} 2>/dev/null || true
       - >
         docker run -d --name {{.CONTAINER_NAME}} -p 9092:9092
         -e KAFKA_ZOOKEEPER_CONNECT=zookeeper-server:2181

--- a/docker-kafka/Taskfile.yml
+++ b/docker-kafka/Taskfile.yml
@@ -1,5 +1,10 @@
 version: 3
 
+includes:
+  docker-zookeeper:
+    taskfile: ../docker-zookeeper/Taskfile.yml
+    dir: ../docker-zookeeper
+
 vars:
   IMAGE: bitnami/kafka:latest
   CONTAINER_NAME: kafka-server

--- a/docker-postgres/Taskfile.yml
+++ b/docker-postgres/Taskfile.yml
@@ -1,0 +1,54 @@
+version: 3
+
+vars:
+  IMAGE: postgres:16
+  CONTAINER_NAME: postgres-server
+
+tasks:
+  default: task --list-all
+
+  create:
+    desc: Run the PostgreSQL container
+    cmds:
+      - docker run -d --name {{.CONTAINER_NAME}} -p 5432:5432 -e POSTGRES_PASSWORD=password {{.IMAGE}}
+    silent: true
+
+  stop:
+    desc: Stop the PostgreSQL container
+    cmds:
+      - docker stop {{.CONTAINER_NAME}}
+    silent: true
+
+  remove:
+    desc: Remove the PostgreSQL container
+    cmds:
+      - docker rm -f {{.CONTAINER_NAME}}
+    silent: true
+
+  logs:
+    desc: View the logs of the PostgreSQL container
+    cmds:
+      - docker logs {{.CONTAINER_NAME}}
+    silent: false
+
+  cli:
+    desc: Open a psql shell in the PostgreSQL container
+    cmds:
+      - docker exec -it {{.CONTAINER_NAME}} psql -U postgres
+    silent: false
+
+  status:
+    desc: Check the status of the PostgreSQL container
+    cmds:
+      - docker ps -a --filter "name={{.CONTAINER_NAME}}"
+    silent: true
+
+  test:
+    desc: Run a test command in the PostgreSQL container
+    cmds:
+      - task: create
+      - task: status
+      - task: logs
+      - task: remove
+      - task: status
+    silent: false

--- a/docker-zookeeper/Taskfile.yml
+++ b/docker-zookeeper/Taskfile.yml
@@ -1,0 +1,54 @@
+version: 3
+
+vars:
+  IMAGE: bitnami/zookeeper:latest
+  CONTAINER_NAME: zookeeper-server
+
+tasks:
+  default: task --list-all
+
+  create:
+    desc: Run the Zookeeper container
+    cmds:
+      - docker run -d --name {{.CONTAINER_NAME}} -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes {{.IMAGE}}
+    silent: true
+
+  stop:
+    desc: Stop the Zookeeper container
+    cmds:
+      - docker stop {{.CONTAINER_NAME}}
+    silent: true
+
+  remove:
+    desc: Remove the Zookeeper container
+    cmds:
+      - docker rm -f {{.CONTAINER_NAME}}
+    silent: true
+
+  logs:
+    desc: View the logs of the Zookeeper container
+    cmds:
+      - docker logs {{.CONTAINER_NAME}}
+    silent: false
+
+  cli:
+    desc: Open a shell in the Zookeeper container
+    cmds:
+      - docker exec -it {{.CONTAINER_NAME}} bash
+    silent: false
+
+  status:
+    desc: Check the status of the Zookeeper container
+    cmds:
+      - docker ps -a --filter "name={{.CONTAINER_NAME}}"
+    silent: true
+
+  test:
+    desc: Run a test command in the Zookeeper container
+    cmds:
+      - task: create
+      - task: status
+      - task: logs
+      - task: remove
+      - task: status
+    silent: false

--- a/docker-zookeeper/Taskfile.yml
+++ b/docker-zookeeper/Taskfile.yml
@@ -10,8 +10,9 @@ tasks:
   create:
     desc: Run the Zookeeper container
     cmds:
+      - docker network create taskops-net 2>/dev/null || true
       - docker rm -f {{.CONTAINER_NAME}} 2>/dev/null || true
-      - docker run -d --name {{.CONTAINER_NAME}} -p 2181:2181 -e ZOO_4LW_COMMANDS_WHITELIST=* {{.IMAGE}}
+      - docker run -d --name {{.CONTAINER_NAME}} --network taskops-net -p 2181:2181 -e ZOO_4LW_COMMANDS_WHITELIST=* {{.IMAGE}}
     silent: true
 
   stop:

--- a/docker-zookeeper/Taskfile.yml
+++ b/docker-zookeeper/Taskfile.yml
@@ -10,6 +10,7 @@ tasks:
   create:
     desc: Run the Zookeeper container
     cmds:
+      - docker rm -f {{.CONTAINER_NAME}} 2>/dev/null || true
       - docker run -d --name {{.CONTAINER_NAME}} -p 2181:2181 -e ZOO_4LW_COMMANDS_WHITELIST=* {{.IMAGE}}
     silent: true
 

--- a/docker-zookeeper/Taskfile.yml
+++ b/docker-zookeeper/Taskfile.yml
@@ -15,6 +15,22 @@ tasks:
       - docker run -d --name {{.CONTAINER_NAME}} --network taskops-net -p 2181:2181 -e ZOO_4LW_COMMANDS_WHITELIST=* {{.IMAGE}}
     silent: true
 
+  wait:
+    desc: Wait for Zookeeper to be ready (up to 30s)
+    cmds:
+      - |
+        for i in $(seq 1 15); do
+          if echo ruok | docker exec -i {{.CONTAINER_NAME}} nc localhost 2181 2>/dev/null | grep -q imok; then
+            echo "Zookeeper is ready"
+            exit 0
+          fi
+          echo "Waiting for Zookeeper... (attempt $i/15)"
+          sleep 2
+        done
+        echo "Zookeeper failed to start"
+        exit 1
+    silent: true
+
   stop:
     desc: Stop the Zookeeper container
     cmds:
@@ -49,6 +65,7 @@ tasks:
     desc: Run a test command in the Zookeeper container
     cmds:
       - task: create
+      - task: wait
       - task: status
       - task: logs
       - task: remove

--- a/docker-zookeeper/Taskfile.yml
+++ b/docker-zookeeper/Taskfile.yml
@@ -1,7 +1,7 @@
 version: 3
 
 vars:
-  IMAGE: bitnami/zookeeper:latest
+  IMAGE: zookeeper:latest
   CONTAINER_NAME: zookeeper-server
 
 tasks:
@@ -10,7 +10,7 @@ tasks:
   create:
     desc: Run the Zookeeper container
     cmds:
-      - docker run -d --name {{.CONTAINER_NAME}} -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes {{.IMAGE}}
+      - docker run -d --name {{.CONTAINER_NAME}} -p 2181:2181 -e ZOO_4LW_COMMANDS_WHITELIST=* {{.IMAGE}}
     silent: true
 
   stop:

--- a/kube-kafka/Taskfile.yml
+++ b/kube-kafka/Taskfile.yml
@@ -1,0 +1,61 @@
+version: 3
+
+vars:
+  IMAGE: bitnami/kafka:latest
+  CONTAINER_NAME: kafka-server
+
+tasks:
+  default: task --list-all
+
+  create:
+    desc: Run the Kafka container
+    cmds:
+      - kubectl apply -f kafka.yaml
+    silent: true
+
+  status:
+    desc: Check the status of the Kafka container
+    cmds:
+      - kubectl get pods -l app=kafka
+    silent: true
+
+  wait:
+    desc: Wait for the Kafka container to be ready
+    cmds:
+      - kubectl wait --for=condition=Ready pod -l app=kafka --timeout=120s
+    silent: true
+
+  remove:
+    desc: Remove the Kafka container
+    cmds:
+      - kubectl delete -f kafka.yaml
+    silent: true
+
+  logs:
+    desc: View the logs of the Kafka container
+    cmds:
+      - kubectl logs -l app=kafka
+    silent: false
+
+  cli:
+    vars:
+      POD:
+        sh: |
+          kubectl get pods -l app=kafka -o jsonpath='{.items[0].metadata.name}'
+    desc: Open a shell in the Kafka container
+    cmds:
+      - kubectl exec -it {{.POD}} -- bash
+    silent: false
+
+  test:
+    desc: Run a test for Kafka (starts Zookeeper, then Kafka)
+    cmds:
+      - task: kube-zookeeper:create
+      - task: kube-zookeeper:wait
+      - task: create
+      - task: wait
+      - task: status
+      - task: logs
+      - task: remove
+      - task: kube-zookeeper:remove
+    silent: false

--- a/kube-kafka/Taskfile.yml
+++ b/kube-kafka/Taskfile.yml
@@ -1,5 +1,10 @@
 version: 3
 
+includes:
+  kube-zookeeper:
+    taskfile: ../kube-zookeeper/Taskfile.yml
+    dir: ../kube-zookeeper
+
 vars:
   IMAGE: bitnami/kafka:latest
   CONTAINER_NAME: kafka-server

--- a/kube-kafka/Taskfile.yml
+++ b/kube-kafka/Taskfile.yml
@@ -1,10 +1,5 @@
 version: 3
 
-includes:
-  kube-zookeeper:
-    taskfile: ../kube-zookeeper/Taskfile.yml
-    dir: ../kube-zookeeper
-
 vars:
   IMAGE: apache/kafka:latest
   CONTAINER_NAME: kafka-server
@@ -55,12 +50,12 @@ tasks:
   test:
     desc: Run a test for Kafka (starts Zookeeper, then Kafka)
     cmds:
-      - task: kube-zookeeper:create
-      - task: kube-zookeeper:wait
+      - task -d .. kube-zookeeper:create
+      - task -d .. kube-zookeeper:wait
       - task: create
       - task: wait
       - task: status
       - task: logs
       - task: remove
-      - task: kube-zookeeper:remove
+      - task -d .. kube-zookeeper:remove
     silent: false

--- a/kube-kafka/Taskfile.yml
+++ b/kube-kafka/Taskfile.yml
@@ -6,7 +6,7 @@ includes:
     dir: ../kube-zookeeper
 
 vars:
-  IMAGE: bitnami/kafka:latest
+  IMAGE: apache/kafka:latest
   CONTAINER_NAME: kafka-server
 
 tasks:

--- a/kube-kafka/Taskfile.yml
+++ b/kube-kafka/Taskfile.yml
@@ -48,14 +48,14 @@ tasks:
     silent: false
 
   test:
-    desc: Run a test for Kafka (starts Zookeeper, then Kafka)
+    desc: Run a test for Kafka (requires Zookeeper to be running)
+    preconditions:
+      - sh: kubectl get pods -l app=zookeeper -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running
+        msg: "Zookeeper is not running. Start it first with: task kube-zookeeper:create && task kube-zookeeper:wait"
     cmds:
-      - task -d .. kube-zookeeper:create
-      - task -d .. kube-zookeeper:wait
       - task: create
       - task: wait
       - task: status
       - task: logs
       - task: remove
-      - task -d .. kube-zookeeper:remove
     silent: false

--- a/kube-kafka/kafka.yaml
+++ b/kube-kafka/kafka.yaml
@@ -14,18 +14,18 @@ spec:
     spec:
       containers:
         - name: kafka
-          image: bitnami/kafka:latest
+          image: apache/kafka:latest
           ports:
             - containerPort: 9092
           env:
-            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+            - name: KAFKA_ZOOKEEPER_CONNECT
               value: "zookeeper:2181"
-            - name: KAFKA_CFG_LISTENERS
+            - name: KAFKA_LISTENERS
               value: "PLAINTEXT://:9092"
-            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+            - name: KAFKA_ADVERTISED_LISTENERS
               value: "PLAINTEXT://kafka:9092"
-            - name: ALLOW_PLAINTEXT_LISTENER
-              value: "yes"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT"
           resources:
             requests:
               memory: "256Mi"

--- a/kube-kafka/kafka.yaml
+++ b/kube-kafka/kafka.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: bitnami/kafka:latest
+          ports:
+            - containerPort: 9092
+          env:
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              value: "zookeeper:2181"
+            - name: KAFKA_CFG_LISTENERS
+              value: "PLAINTEXT://:9092"
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka:9092"
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  selector:
+    app: kafka
+  ports:
+    - port: 9092
+      targetPort: 9092

--- a/kube-postgres/Taskfile.yml
+++ b/kube-postgres/Taskfile.yml
@@ -1,0 +1,58 @@
+version: 3
+
+vars:
+  IMAGE: postgres:16
+  CONTAINER_NAME: postgres-server
+
+tasks:
+  default: task --list-all
+
+  create:
+    desc: Run the PostgreSQL container
+    cmds:
+      - kubectl apply -f postgres.yaml
+    silent: true
+
+  status:
+    desc: Check the status of the PostgreSQL container
+    cmds:
+      - kubectl get pods -l app=postgres
+    silent: true
+
+  wait:
+    desc: Wait for the PostgreSQL container to be ready
+    cmds:
+      - kubectl wait --for=condition=Ready pod -l app=postgres --timeout=60s
+    silent: true
+
+  remove:
+    desc: Remove the PostgreSQL container
+    cmds:
+      - kubectl delete -f postgres.yaml
+    silent: true
+
+  logs:
+    desc: View the logs of the PostgreSQL container
+    cmds:
+      - kubectl logs -l app=postgres
+    silent: false
+
+  cli:
+    vars:
+      POD:
+        sh: |
+          kubectl get pods -l app=postgres -o jsonpath='{.items[0].metadata.name}'
+    desc: Open a psql shell in the PostgreSQL container
+    cmds:
+      - kubectl exec -it {{.POD}} -- psql -U postgres
+    silent: false
+
+  test:
+    desc: Run a test command in the PostgreSQL container
+    cmds:
+      - task: create
+      - task: wait
+      - task: status
+      - task: logs
+      - task: remove
+    silent: false

--- a/kube-postgres/postgres.yaml
+++ b/kube-postgres/postgres.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_PASSWORD
+              value: password
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/kube-zookeeper/Taskfile.yml
+++ b/kube-zookeeper/Taskfile.yml
@@ -1,0 +1,58 @@
+version: 3
+
+vars:
+  IMAGE: bitnami/zookeeper:latest
+  CONTAINER_NAME: zookeeper-server
+
+tasks:
+  default: task --list-all
+
+  create:
+    desc: Run the Zookeeper container
+    cmds:
+      - kubectl apply -f zookeeper.yaml
+    silent: true
+
+  status:
+    desc: Check the status of the Zookeeper container
+    cmds:
+      - kubectl get pods -l app=zookeeper
+    silent: true
+
+  wait:
+    desc: Wait for the Zookeeper container to be ready
+    cmds:
+      - kubectl wait --for=condition=Ready pod -l app=zookeeper --timeout=60s
+    silent: true
+
+  remove:
+    desc: Remove the Zookeeper container
+    cmds:
+      - kubectl delete -f zookeeper.yaml
+    silent: true
+
+  logs:
+    desc: View the logs of the Zookeeper container
+    cmds:
+      - kubectl logs -l app=zookeeper
+    silent: false
+
+  cli:
+    vars:
+      POD:
+        sh: |
+          kubectl get pods -l app=zookeeper -o jsonpath='{.items[0].metadata.name}'
+    desc: Open a shell in the Zookeeper container
+    cmds:
+      - kubectl exec -it {{.POD}} -- bash
+    silent: false
+
+  test:
+    desc: Run a test command in the Zookeeper container
+    cmds:
+      - task: create
+      - task: wait
+      - task: status
+      - task: logs
+      - task: remove
+    silent: false

--- a/kube-zookeeper/Taskfile.yml
+++ b/kube-zookeeper/Taskfile.yml
@@ -1,7 +1,7 @@
 version: 3
 
 vars:
-  IMAGE: bitnami/zookeeper:latest
+  IMAGE: zookeeper:latest
   CONTAINER_NAME: zookeeper-server
 
 tasks:

--- a/kube-zookeeper/zookeeper.yaml
+++ b/kube-zookeeper/zookeeper.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: bitnami/zookeeper:latest
+          ports:
+            - containerPort: 2181
+          env:
+            - name: ALLOW_ANONYMOUS_LOGIN
+              value: "yes"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+spec:
+  selector:
+    app: zookeeper
+  ports:
+    - port: 2181
+      targetPort: 2181

--- a/kube-zookeeper/zookeeper.yaml
+++ b/kube-zookeeper/zookeeper.yaml
@@ -14,12 +14,12 @@ spec:
     spec:
       containers:
         - name: zookeeper
-          image: bitnami/zookeeper:latest
+          image: zookeeper:latest
           ports:
             - containerPort: 2181
           env:
-            - name: ALLOW_ANONYMOUS_LOGIN
-              value: "yes"
+            - name: ZOO_4LW_COMMANDS_WHITELIST
+              value: "*"
           resources:
             requests:
               memory: "128Mi"


### PR DESCRIPTION
Solves Issue #4 and Issue #6.

Adds Taskfile-based deployers for PostgreSQL, Kafka, and Zookeeper, following the existing docker-redis / kube-redis pattern:

PostgreSQL (docker-postgres, kube-postgres) — image: postgres:16
Zookeeper (docker-zookeeper, kube-zookeeper) — image: zookeeper:latest
Kafka (docker-kafka, kube-kafka) — image: kafka

Each deployer includes full lifecycle tasks (create, start, stop, remove, logs, status, test). Kubernetes deployers include manifests with Deployment + Service resources.
